### PR TITLE
ITU-T Liaison Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# liaison-templates
-IETF Liaison Templates
+# IETF Liaison Templates and Coordination 
+
+## Introduction
+All incoming liaisons are replied to by the liaison manager using email (in a timely fashion).  Liaison responses are either boilerplate or crafted using with the following guidelines:
+1. Informational
+  * The liaison manager sends an __email__ acknowledging receipt
+     * For IETF: [Template-Email-IETF-Info](Template-Email-IETF-Info.md)
+     * For IRTF: [Template-Email-IRTF](Template-Email-IRTF.md)
+  * An __outgoing liaison__ can be sent, but the default case is that no official liaison reply is sent.
+2. Action
+  * The liaison manager sends an __email__ acknowledging receipt
+     * For IETF: [Template-Email-IETF-Action](Template-Email-IETF-Action.md)
+     * For IRTF: [Template-Email-IRTF](Template-Email-IRTF.md)
+       * Note:  IRTF uses same template for Incoming Liaisons regardless of status.
+  * Before the __deadline__ one of two things happens
+     * The liaison manager sends a boilerplate liaison response
+       * For IETF: [Template-Liaison-IETF-Action-Response](Template-Liaison-IETF-Action-Response.md)
+       * For IRTF: [Template-Liaison-IRTF-Action-Response](Template-Liaison-IRTF-Action-Response.md)
+
+     --or--
+
+     * The liaison manager coordinates a crafted liaison response with the interested parties from the IETF/IAB/IRTF etc.  There is no template for this type of response.

--- a/Template-Email-IETF-Action.md
+++ b/Template-Email-IETF-Action.md
@@ -1,0 +1,7 @@
+Thank you {insert group name} for your incoming liaison statement {insert title}.  The appropriate part(s) of the IETF community have been made aware of your message and the liaison statement has been logged in the IETF's Liaison Statement Database {insert link}.
+
+Since the incoming liaison statement was marked as “For Action”, discussion of the content of the liaison statement will be discussed with the working group(s) indicated.  The creation of a formal liaison response is governed by the process noted below.
+
+The IETF is a contribution driven organization, with a formal process described in [Internet Standards Process](https://www.ietf.org/process/process) (1). IETF positions require community rough consensus with input from Working Groups via the process managed by the Internet Engineering Steering Group (IESG). Without going through the IETF's defined process to gather consensus, the IETF has no official position on any topic, including Liaison Statements.
+
+(1) Internet Standards Process https://www.ietf.org/process/process

--- a/Template-Email-IETF-Info.md
+++ b/Template-Email-IETF-Info.md
@@ -1,0 +1,5 @@
+Thank you {insert group name} for your incoming liaison statement {insert title}.  The appropriate part(s) of the IETF community have been made aware of your message and the liaison statement has been logged in the IETF's Liaison Statement Database {insert link}.
+
+The IETF is a contribution driven organization, with a formal process described in [Internet Standards Process](https://www.ietf.org/process/process) (1). IETF positions require community rough consensus with input from Working Groups via the process managed by the Internet Engineering Steering Group (IESG). Without going through the IETF's defined process to gather consensus, the IETF has no official position on any topic, including Liaison Statements.
+
+(1) Internet Standards Process https://www.ietf.org/process/process

--- a/Template-Email-IRTF.md
+++ b/Template-Email-IRTF.md
@@ -1,0 +1,6 @@
+Thank you {insert group name} for your incoming liaison statement {insert title}.  The appropriate part(s) of the IRTF community have been made aware of your message and the liaison statement has been logged in the IETF's Liaison Database {insert link}.
+
+The IRTF is a contribution driven research-oriented organization, with guidelines and procedures described in [IRTF Policies and Procedures](https://www.irtf.org/policies) (1).  Each IRTF Research Group is permitted to agree on working methods that fit the needs of the Research Group.  However, without going through the IETF's defined process to gather consensus (2), the IRTF has no official position on any topic, including Liaison Statements.
+
+(1) IRTF Policies and Procedures https://www.irtf.org/policies
+(2) Internet Standards Process https://www.ietf.org/process/process

--- a/Template-Liaison-IETF-Action-Response.md
+++ b/Template-Liaison-IETF-Action-Response.md
@@ -1,0 +1,5 @@
+Thank you {insert group name} for your incoming liaison statement {insert title}.  The IETF community has not reached consensus on a response to the liaison statement.  This lack of consensus does not indicate agreement to or concurrence with any outcome; nor does it indicate that the IETF will not gain consensus on some aspect of it in the future.
+
+The IETF is a contribution driven organization, with a formal process described in [Internet Standards Process](https://www.ietf.org/process/process) (1). IETF positions require community rough consensus with input from Working Groups via the process managed by the Internet Engineering Steering Group (IESG). Without going through the IETF's defined process to gather consensus, the IETF has no official position on any topic, including Liaison Statements.
+
+(1) Internet Standards Process https://www.ietf.org/process/process

--- a/Template-Liaison-IRTF-Action-Response.md
+++ b/Template-Liaison-IRTF-Action-Response.md
@@ -1,0 +1,8 @@
+Thank you {insert group name} for your incoming liaison statement {insert title}.  
+
+The IRTF takes no position on the content of the liaison statement received.
+
+The IRTF is a contribution driven research-oriented organization, with guidelines and procedures described in [IRTF Policies and Procedures](https://www.irtf.org/policies) (1).  Each IRTF Research Group is permitted to agree on working methods that fit the needs of the Research Group.  However, without going through the IETF's defined process to gather consensus (2), the IRTF has no official position on any topic, including Liaison Statements.
+
+(1) IRTF Policies and Procedures https://www.irtf.org/policies
+(2) Internet Standards Process https://www.ietf.org/process/process


### PR DESCRIPTION
ITU-T Liaison Templates.
This is the initial submission of the templates to use to respond to incoming ITU-T Liaisons.  For each incoming liaison an email response will be sent to indicate the IETF received the liaison. 